### PR TITLE
Add an `-e` / `-env` option to check dependencies from a venv by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Check if your current environment is ready for the latest Python:
 python_readiness
 ```
 
+Check if another virtual environment is ready for the latest Python:
+```bash
+python_readiness -e path/to/.venv
+```
+
 Check if a specific package is ready for a specific Python:
 ```bash
 python_readiness -p numpy --python 3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{name = "Shantanu Jain"}, {email = "hauntsaninja@gmail.com"}]
 description = "Are your dependencies ready for new Python?"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = [
     "aiohttp>=3.10",
     "packaging>=24",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,11 @@ authors = [{name = "Shantanu Jain"}, {email = "hauntsaninja@gmail.com"}]
 description = "Are your dependencies ready for new Python?"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.10",
     "packaging>=24",
+    "pip>=24.2",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ requires-python = ">=3.9"
 dependencies = [
     "aiohttp>=3.10",
     "packaging>=24",
-    "pip>=24.2",
 ]
 
 [project.scripts]

--- a/python_readiness.py
+++ b/python_readiness.py
@@ -461,8 +461,6 @@ def requirements_from_ext_environment(env_path: Path) -> list[Requirement]:
             "-m", "pip",
             "--python", env_str,
             "list",
-            "--exclude-editable",
-            "--exclude", "pip",
             "--format", "json",
         ],
         capture_output=True,

--- a/python_readiness.py
+++ b/python_readiness.py
@@ -3,7 +3,7 @@
 # dependencies = [
 #     "aiohttp>=3.10",
 #     "packaging>=24",
-#     "pip>=24.2",  # pip is required for subprocess, uv won't include it by default
+#     "pip>=24.2",  # pip is required for subprocess, tools may not include it by default
 # ]
 # ///
 from __future__ import annotations

--- a/python_readiness.py
+++ b/python_readiness.py
@@ -481,6 +481,7 @@ def requirements_from_ext_environment(env_path: Path) -> list[Requirement]:
         name = package.get("name")
         version = package.get("version")
         if name and version:
+            version = Version(version).base_version
             requirements.append(Requirement(f"{name}>={version}"))
 
     return requirements

--- a/python_readiness.py
+++ b/python_readiness.py
@@ -489,7 +489,6 @@ def requirements_from_ext_environment(env_path: str) -> list[Requirement]:
             text=True,
         )
     except FileNotFoundError:
-        # The original error is incredibly long
         raise RuntimeError(f"Could not find Python environment at {env_path}")
 
     if result.returncode != 0:

--- a/python_readiness.py
+++ b/python_readiness.py
@@ -3,7 +3,7 @@
 # dependencies = [
 #     "aiohttp>=3.10",
 #     "packaging>=24",
-#     "pip>=24.2",  # pip is required for subprocess, tools may not include it by default
+#     "pip>=24.2",  # used via subprocess
 # ]
 # ///
 from __future__ import annotations

--- a/python_readiness.py
+++ b/python_readiness.py
@@ -452,14 +452,13 @@ def requirements_from_environment() -> list[Requirement]:
     return [Requirement(f"{name}>={version}") for name, version in venv_versions.items()]
 
 
-def requirements_from_ext_environment(env_path: Path) -> list[Requirement]:
+def requirements_from_ext_environment(env_path: str) -> list[Requirement]:
     # Query PIP to get the external environment packages
-    env_str = str(env_path.resolve())
     freeze = subprocess.run(
         [
             sys.executable,
             "-m", "pip",
-            "--python", env_str,
+            "--python", env_path,
             "list",
             "--format", "json",
         ],
@@ -506,7 +505,7 @@ async def python_readiness(
 
     if envs:
         for env in envs:
-            packages.extend(requirements_from_ext_environment(Path(env)))
+            packages.extend(requirements_from_ext_environment(env))
 
     if not packages:
         # Default to pulling "requirements" from the current environment

--- a/python_readiness.py
+++ b/python_readiness.py
@@ -467,8 +467,14 @@ def requirements_from_ext_environment(env_path: Path) -> list[Requirement]:
         ],
         capture_output=True,
         text=True,
-        check=True,
     )
+
+    if freeze.returncode != 0:
+        err = (
+            f"Failed to read environment data from {env_path}\n"
+            f"pip error Message: \"{freeze.stderr.strip()}\""
+        )
+        raise RuntimeError(err)
 
     packages = json.loads(freeze.stdout)
 

--- a/python_readiness.py
+++ b/python_readiness.py
@@ -498,14 +498,15 @@ async def python_readiness(
     python_version: tuple[int, int] | None,
     req_files: list[str],
     ignore_existing_requirements: bool,
-    envs: list[str],
+    envs: list[str] | None = None,
 ) -> str:
 
     for req_file in req_files:
         packages.extend(Requirement(req) for req in parse_requirements_txt(req_file))
 
-    for env in envs:
-        packages.extend(requirements_from_ext_environment(Path(env)))
+    if envs:
+        for env in envs:
+            packages.extend(requirements_from_ext_environment(Path(env)))
 
     if not packages:
         # Default to pulling "requirements" from the current environment

--- a/test_python_readiness.py
+++ b/test_python_readiness.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import tempfile
+import sys
 from pathlib import Path
 from typing import Any, Callable, Coroutine
 
@@ -21,6 +22,7 @@ from python_readiness import (
     parse_requirements_txt,
     previous_minor_python_version,
     requirements_from_environment,
+    requirements_from_ext_environment,
     safe_version,
     support_from_wheel_tags_helper,
     tag_viable_for_python,
@@ -168,6 +170,18 @@ def test_deduplicate_reqs() -> None:
 
 def test_requirements_from_environment() -> None:
     reqs = {canonical_name(r.name): r for r in requirements_from_environment()}
+    assert reqs["aiohttp"]
+    assert Version("3.9") not in reqs["aiohttp"].specifier
+    assert Version("9999") in reqs["aiohttp"].specifier
+
+    assert reqs["pytest"]
+    assert Version("5") not in reqs["pytest"].specifier
+    assert Version("9999") in reqs["pytest"].specifier
+
+
+def test_requirements_from_ext_environment() -> None:
+    this_env = Path(sys.prefix)
+    reqs = {canonical_name(r.name): r for r in requirements_from_ext_environment(this_env)}
     assert reqs["aiohttp"]
     assert Version("3.9") not in reqs["aiohttp"].specifier
     assert Version("9999") in reqs["aiohttp"].specifier

--- a/test_python_readiness.py
+++ b/test_python_readiness.py
@@ -180,13 +180,11 @@ def test_requirements_from_environment() -> None:
 
 
 def test_requirements_from_ext_environment() -> None:
-    this_env = Path(sys.prefix)
-
     # Both methods should give the same result for the active venv
-    assert requirements_from_environment() == requirements_from_ext_environment(this_env)
+    assert requirements_from_environment() == requirements_from_ext_environment(sys.prefix)
 
     with pytest.raises(RuntimeError):
-        _ = requirements_from_ext_environment(Path(sys.prefix) / "not_a_venv")
+        _ = requirements_from_ext_environment(str(Path(sys.prefix) / "not_a_venv"))
 
 
 def we_have_pytest_asyncio_at_home(

--- a/test_python_readiness.py
+++ b/test_python_readiness.py
@@ -349,6 +349,7 @@ async def test_python_readiness_e2e() -> None:
         req_files=[],
         python_version=(3, 11),
         ignore_existing_requirements=True,
+        envs=[],
     )
     assert (
         readiness
@@ -370,6 +371,7 @@ blobfile                                  # has_viable_wheel (cannot ensure supp
         req_files=[],
         python_version=(3, 11),
         ignore_existing_requirements=False,
+        envs=[],
     )
     print(readiness)
     assert (

--- a/test_python_readiness.py
+++ b/test_python_readiness.py
@@ -190,6 +190,9 @@ def test_requirements_from_ext_environment() -> None:
     assert Version("5") not in reqs["pytest"].specifier
     assert Version("9999") in reqs["pytest"].specifier
 
+    with pytest.raises(RuntimeError):
+        _ = requirements_from_ext_environment(Path(sys.prefix) / "not_a_venv")
+
 
 def we_have_pytest_asyncio_at_home(
     fn: Callable[[], Coroutine[Any, Any, None]]

--- a/test_python_readiness.py
+++ b/test_python_readiness.py
@@ -347,7 +347,6 @@ async def test_python_readiness_e2e() -> None:
         req_files=[],
         python_version=(3, 11),
         ignore_existing_requirements=True,
-        envs=[],
     )
     assert (
         readiness
@@ -369,7 +368,6 @@ blobfile                                  # has_viable_wheel (cannot ensure supp
         req_files=[],
         python_version=(3, 11),
         ignore_existing_requirements=False,
-        envs=[],
     )
     print(readiness)
     assert (

--- a/test_python_readiness.py
+++ b/test_python_readiness.py
@@ -181,14 +181,9 @@ def test_requirements_from_environment() -> None:
 
 def test_requirements_from_ext_environment() -> None:
     this_env = Path(sys.prefix)
-    reqs = {canonical_name(r.name): r for r in requirements_from_ext_environment(this_env)}
-    assert reqs["aiohttp"]
-    assert Version("3.9") not in reqs["aiohttp"].specifier
-    assert Version("9999") in reqs["aiohttp"].specifier
 
-    assert reqs["pytest"]
-    assert Version("5") not in reqs["pytest"].specifier
-    assert Version("9999") in reqs["pytest"].specifier
+    # Both methods should give the same result for the active venv
+    assert requirements_from_environment() == requirements_from_ext_environment(this_env)
 
     with pytest.raises(RuntimeError):
         _ = requirements_from_ext_environment(Path(sys.prefix) / "not_a_venv")

--- a/test_python_readiness.py
+++ b/test_python_readiness.py
@@ -181,7 +181,14 @@ def test_requirements_from_environment() -> None:
 
 def test_requirements_from_ext_environment() -> None:
     # Both methods should give the same result for the active venv
-    assert requirements_from_environment() == requirements_from_ext_environment(sys.prefix)
+    from_env = sorted(
+        requirements_from_environment(),
+        key=lambda x: str(x)
+    )
+    from_ext_env = sorted(
+        requirements_from_ext_environment(sys.prefix),
+        key=lambda x: str(x)
+    )
 
     with pytest.raises(RuntimeError):
         _ = requirements_from_ext_environment(str(Path(sys.prefix) / "not_a_venv"))


### PR DESCRIPTION
Not sure if you're taking pull requests but I figured I'd make one in case you'd also find this useful. If not you can just close this.

I tried using `uvx python_readiness` and noticed that the tool checked the environment that *it* was in, which in that case is the one created by `uv` to run the tool and not the original environment.

In order to check an environment other than the one the script is running in I've added a `requirements_from_ext_environment` function that uses a subprocess call to `python -m pip --python [venv path] list --format json` to get the information.

This also adds a corresponding optional `envs` argument to `python_readiness` with an `-e` / `--env`  option to the command line parser. This means `uvx python_readiness -e .venv` would be able to be used to check a project venv without needing to be installed in that env.